### PR TITLE
fix: update related block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Are you using this project or any of our other projects? Consider [leaving a tes
 Check out these related projects.
 
 - [terraform-null-label](https://github.com/cloudposse/terraform-null-label) - Terraform Module to define a consistent naming convention by (namespace, stage, name, [attributes])
-- [terraform-cloudflare-zone](https://github.com/cloudposse/terraform-cloudflare-zone) - %!s(<nil>)
+- [terraform-cloudflare-zone](https://github.com/cloudposse/terraform-cloudflare-zone) - Terraform module to provision a CloudFlare zone with DNS records, Argo, Firewall filters and rules
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -37,7 +37,7 @@ related:
     stage, name, [attributes])
   url: https://github.com/cloudposse/terraform-null-label
 - name: terraform-cloudflare-zone
-  description:
+  description: Terraform module to provision a CloudFlare zone with DNS records, Argo, Firewall filters and rules
   url: https://github.com/cloudposse/terraform-cloudflare-zone
 references:
 - name: terraform-provider-cloudflare


### PR DESCRIPTION
## what
* update related block in README

## why
* was missed `description` for `terraform-cloudflare-waf-rulesets` in the related block


